### PR TITLE
Tf example multi gpu corrected

### DIFF
--- a/examples/tf/mnist_submission_script.slurm
+++ b/examples/tf/mnist_submission_script.slurm
@@ -15,7 +15,6 @@ set -x
 cd $WORK/jean-zay-doc/examples/tf
 
 module purge
-module load python/3.7.5
 module load tensorflow-gpu/py3/2.1.0
 
 srun python ./mnist_example.py -s&

--- a/examples/tf/mnist_submission_script_multi_gpus.slurm
+++ b/examples/tf/mnist_submission_script_multi_gpus.slurm
@@ -17,7 +17,6 @@ cd $WORK/jean-zay-doc/examples/tf
 module purge
 module load tensorflow-gpu/py3/2.1.0
 
-srun --ntasks=1 python ./mnist_example.py -gpus 0&
-srun --ntasks=1 python ./mnist_example.py -gpus 1&
+srun --multi-prog ./mpmd_multi_gpu.conf
 
 wait

--- a/examples/tf/mnist_submission_script_multi_gpus.slurm
+++ b/examples/tf/mnist_submission_script_multi_gpus.slurm
@@ -15,7 +15,6 @@ set -x
 cd $WORK/jean-zay-doc/examples/tf
 
 module purge
-module load python/3.7.5
 module load tensorflow-gpu/py3/2.1.0
 
 srun --ntasks=1 python ./mnist_example.py -gpus 0&

--- a/examples/tf/mpmd_multi_gpu.conf
+++ b/examples/tf/mpmd_multi_gpu.conf
@@ -1,0 +1,2 @@
+0 python ./mnist_example.py -gpus 0
+1 python ./mnist_example.py -gpus 1


### PR DESCRIPTION
This PR uses the [canonical way yo do multi-gpu](https://github.com/jean-zay-users/jean-zay-doc/issues/9#issuecomment-595456475).

I also took advantage of it to follow the assitance's advice and remove the load of python3 when using tensorflow.