### PR TITLE
Pytorch example

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,27 @@ If you need to send data to Jean-Zay a good idea is to use `rsync`. E.g.:
 rsync -avz -e ssh --progress  user@jeanzay:/gpfsscratch/your/remote/dir/ /your/local/database/
 ```
 
+## How to use interactive mode
+
+Interactive mode using SLURM  can be done by using two commands:
+`salloc` and `srun`.  First, you need to reserve the  
+ressources you want ot use. For example, if you need a node with 4 GPUs during 1
+hour, you can type:
+
+``` 
+salloc --ntasks=1 --cpus-per-task=40 --gres=gpu:4 --hint=nomultithread --time=01:00:00
+```
+
+Then, you can launch an interactive shell using the allocated ressources:
+
+``` 
+srun --pty bash -i 
+```
+
+Now, you have a fresh new shell where you can try your scripts interactivly for
+1h. 
+
+
 ## Generic advice
 
 - Find people that have accessed IDRIS clusters around you. If you have no idea

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ hour, you can type:
 srun --ntasks=1 --gres=gpu:4 --time=01:00:00 --pty bash -i 
 ```
 
-Now, you have a brand new shell where you can try your scripts interactivly
+Now, you have a brand new shell on a compute node where you can run your scripts interactively
 during 1h. 
 
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Hardware: http://www.idris.fr/eng/jean-zay/cpu/jean-zay-cpu-hw-eng.html
 
 Doc: http://www.idris.fr/eng/jean-zay/
 
-## Mananging your data and the storage spaces
+## Managing your data and the storage spaces
 
 Be careful about the place where you put your data on the JZ super-computer,
 since there are quotas for each project, depending on the storage space and the

--- a/README.md
+++ b/README.md
@@ -180,23 +180,17 @@ rsync -avz -e ssh --progress  user@jeanzay:/gpfsscratch/your/remote/dir/ /your/l
 
 ## How to use interactive mode
 
-Interactive mode using SLURM  can be done by using two commands:
-`salloc` and `srun`.  First, you need to reserve the  
-ressources you want ot use. For example, if you need a node with 4 GPUs during 1
+Interactive mode using SLURM can be done by using the command
+`srun`.  
+For example, if you want to use a node with 4 GPUs during 1
 hour, you can type:
 
 ``` 
-salloc --ntasks=1 --cpus-per-task=40 --gres=gpu:4 --hint=nomultithread --time=01:00:00
+srun --ntasks=1 --gres=gpu:4 --time=01:00:00 --pty bash -i 
 ```
 
-Then, you can launch an interactive shell using the allocated ressources:
-
-``` 
-srun --pty bash -i 
-```
-
-Now, you have a fresh new shell where you can try your scripts interactivly for
-1h. 
+Now, you have a brand new shell where you can try your scripts interactivly
+during 1h. 
 
 
 ## Generic advice

--- a/examples/pytorch/README.md
+++ b/examples/pytorch/README.md
@@ -11,3 +11,11 @@ After that, you can just launch the batch job (single GPU) via:
 ```
 sbatch jean-zay-doc/examples/pytorch/pytorch_example_script.sh
 ```
+
+A multi GPU version is also available, it launches the same training with
+several values for a single parameter in multiples GPU (parallelism without sharing
+data). Classical case for simple hyperparameters search:
+```
+sbatch jean-zay-doc/examples/pytorch/pytorch_example_script_multigpu.sh
+```
+

--- a/examples/pytorch/README.md
+++ b/examples/pytorch/README.md
@@ -7,14 +7,17 @@ cd $WORK &&\
 git clone https://github.com/jean-zay-users/jean-zay-doc.git
 ```
 
-After that, you can just launch the batch job (single GPU) via:
+After that, you can launch the batch job (single GPU version) via:
 ```
 sbatch jean-zay-doc/examples/pytorch/pytorch_example_script.sh
 ```
 
-A multi GPU version is also available, it launches the same training with
-several values for a single parameter in multiples GPU (parallelism without sharing
-data). Classical case for simple hyperparameters search:
+Alternatively, a multi GPU version is available. It launches the training with
+10 different values for a single parameter. In SLURM language this is called a
+*job array*.  
+This script implements a kind of parallelism (when data is not shared between
+different jobs). It can be useful to optimize the values of the hyperparameters
+during the training:
 ```
 sbatch jean-zay-doc/examples/pytorch/pytorch_example_script_multigpu.sh
 ```

--- a/examples/pytorch/README.md
+++ b/examples/pytorch/README.md
@@ -1,0 +1,13 @@
+# Tensorflow example script
+
+To run this script you will need to clone the jean-zay repo in your `$WORK`
+dir, then:
+```
+cd $WORK &&\
+git clone https://github.com/jean-zay-users/jean-zay-doc.git
+```
+
+After that, you can just launch the batch job (single GPU) via:
+```
+sbatch jean-zay-doc/examples/pytorch/pytorch_example_script.sh
+```

--- a/examples/pytorch/README.md
+++ b/examples/pytorch/README.md
@@ -1,4 +1,4 @@
-# Tensorflow example script
+# Pytorch example script
 
 To run this script you will need to clone the jean-zay repo in your `$WORK`
 dir, then:

--- a/examples/pytorch/mnist_example.py
+++ b/examples/pytorch/mnist_example.py
@@ -104,14 +104,14 @@ def main():
 
     kwargs = {'num_workers': 1, 'pin_memory': True} if use_cuda else {}
     train_loader = torch.utils.data.DataLoader(
-        datasets.MNIST(os.path.join(os.environ['WORK'], 'data'), train=True, download=False,
+        datasets.MNIST(os.environ['DSDIR'] , train=True, download=False,
                        transform=transforms.Compose([
                            transforms.ToTensor(),
                            transforms.Normalize((0.1307,), (0.3081,))
                        ])),
         batch_size=args.batch_size, shuffle=True, **kwargs)
     test_loader = torch.utils.data.DataLoader(
-        datasets.MNIST(os.path.join(os.environ['WORK'], 'data'), train=False, transform=transforms.Compose([
+        datasets.MNIST(os.environ['DSDIR'], train=False, transform=transforms.Compose([
                            transforms.ToTensor(),
                            transforms.Normalize((0.1307,), (0.3081,))
                        ])),

--- a/examples/pytorch/mnist_example.py
+++ b/examples/pytorch/mnist_example.py
@@ -3,6 +3,8 @@
 
 from __future__ import print_function
 import argparse
+import os
+import os.path
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -102,14 +104,14 @@ def main():
 
     kwargs = {'num_workers': 1, 'pin_memory': True} if use_cuda else {}
     train_loader = torch.utils.data.DataLoader(
-        datasets.MNIST('../data', train=True, download=True,
+        datasets.MNIST(os.path.join(os.environ['WORK'], 'data'), train=True, download=False,
                        transform=transforms.Compose([
                            transforms.ToTensor(),
                            transforms.Normalize((0.1307,), (0.3081,))
                        ])),
         batch_size=args.batch_size, shuffle=True, **kwargs)
     test_loader = torch.utils.data.DataLoader(
-        datasets.MNIST('../data', train=False, transform=transforms.Compose([
+        datasets.MNIST(os.path.join(os.environ['WORK'], 'data'), train=False, transform=transforms.Compose([
                            transforms.ToTensor(),
                            transforms.Normalize((0.1307,), (0.3081,))
                        ])),

--- a/examples/pytorch/mnist_example.py
+++ b/examples/pytorch/mnist_example.py
@@ -1,0 +1,132 @@
+# Taken from the official repository examples: 
+# https://github.com/pytorch/examples/tree/master/mnist
+
+from __future__ import print_function
+import argparse
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim as optim
+from torchvision import datasets, transforms
+from torch.optim.lr_scheduler import StepLR
+
+
+class Net(nn.Module):
+    def __init__(self):
+        super(Net, self).__init__()
+        self.conv1 = nn.Conv2d(1, 32, 3, 1)
+        self.conv2 = nn.Conv2d(32, 64, 3, 1)
+        self.dropout1 = nn.Dropout2d(0.25)
+        self.dropout2 = nn.Dropout2d(0.5)
+        self.fc1 = nn.Linear(9216, 128)
+        self.fc2 = nn.Linear(128, 10)
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = F.relu(x)
+        x = self.conv2(x)
+        x = F.relu(x)
+        x = F.max_pool2d(x, 2)
+        x = self.dropout1(x)
+        x = torch.flatten(x, 1)
+        x = self.fc1(x)
+        x = F.relu(x)
+        x = self.dropout2(x)
+        x = self.fc2(x)
+        output = F.log_softmax(x, dim=1)
+        return output
+
+
+def train(args, model, device, train_loader, optimizer, epoch):
+    model.train()
+    for batch_idx, (data, target) in enumerate(train_loader):
+        data, target = data.to(device), target.to(device)
+        optimizer.zero_grad()
+        output = model(data)
+        loss = F.nll_loss(output, target)
+        loss.backward()
+        optimizer.step()
+        if batch_idx % args.log_interval == 0:
+            print('Train Epoch: {} [{}/{} ({:.0f}%)]\tLoss: {:.6f}'.format(
+                epoch, batch_idx * len(data), len(train_loader.dataset),
+                100. * batch_idx / len(train_loader), loss.item()))
+
+
+def test(args, model, device, test_loader):
+    model.eval()
+    test_loss = 0
+    correct = 0
+    with torch.no_grad():
+        for data, target in test_loader:
+            data, target = data.to(device), target.to(device)
+            output = model(data)
+            test_loss += F.nll_loss(output, target, reduction='sum').item()  # sum up batch loss
+            pred = output.argmax(dim=1, keepdim=True)  # get the index of the max log-probability
+            correct += pred.eq(target.view_as(pred)).sum().item()
+
+    test_loss /= len(test_loader.dataset)
+
+    print('\nTest set: Average loss: {:.4f}, Accuracy: {}/{} ({:.0f}%)\n'.format(
+        test_loss, correct, len(test_loader.dataset),
+        100. * correct / len(test_loader.dataset)))
+
+
+def main():
+    # Training settings
+    parser = argparse.ArgumentParser(description='PyTorch MNIST Example')
+    parser.add_argument('--batch-size', type=int, default=64, metavar='N',
+                        help='input batch size for training (default: 64)')
+    parser.add_argument('--test-batch-size', type=int, default=1000, metavar='N',
+                        help='input batch size for testing (default: 1000)')
+    parser.add_argument('--epochs', type=int, default=14, metavar='N',
+                        help='number of epochs to train (default: 14)')
+    parser.add_argument('--lr', type=float, default=1.0, metavar='LR',
+                        help='learning rate (default: 1.0)')
+    parser.add_argument('--gamma', type=float, default=0.7, metavar='M',
+                        help='Learning rate step gamma (default: 0.7)')
+    parser.add_argument('--no-cuda', action='store_true', default=False,
+                        help='disables CUDA training')
+    parser.add_argument('--seed', type=int, default=1, metavar='S',
+                        help='random seed (default: 1)')
+    parser.add_argument('--log-interval', type=int, default=10, metavar='N',
+                        help='how many batches to wait before logging training status')
+
+    parser.add_argument('--save-model', action='store_true', default=False,
+                        help='For Saving the current Model')
+    args = parser.parse_args()
+    use_cuda = not args.no_cuda and torch.cuda.is_available()
+
+    torch.manual_seed(args.seed)
+
+    device = torch.device("cuda" if use_cuda else "cpu")
+
+    kwargs = {'num_workers': 1, 'pin_memory': True} if use_cuda else {}
+    train_loader = torch.utils.data.DataLoader(
+        datasets.MNIST('../data', train=True, download=True,
+                       transform=transforms.Compose([
+                           transforms.ToTensor(),
+                           transforms.Normalize((0.1307,), (0.3081,))
+                       ])),
+        batch_size=args.batch_size, shuffle=True, **kwargs)
+    test_loader = torch.utils.data.DataLoader(
+        datasets.MNIST('../data', train=False, transform=transforms.Compose([
+                           transforms.ToTensor(),
+                           transforms.Normalize((0.1307,), (0.3081,))
+                       ])),
+        batch_size=args.test_batch_size, shuffle=True, **kwargs)
+
+    model = Net().to(device)
+    optimizer = optim.Adadelta(model.parameters(), lr=args.lr)
+
+    scheduler = StepLR(optimizer, step_size=1, gamma=args.gamma)
+    for epoch in range(1, args.epochs + 1):
+        train(args, model, device, train_loader, optimizer, epoch)
+        test(args, model, device, test_loader)
+        scheduler.step()
+
+    if args.save_model:
+        torch.save(model.state_dict(), "mnist_cnn.pt")
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/pytorch/pytorch_example_script.sh
+++ b/examples/pytorch/pytorch_example_script.sh
@@ -8,7 +8,7 @@
 #SBATCH --distribution=block:block   # we pin the tasks on contiguous cores
 #SBATCH --time=3:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=pytorch_mnist%j.out # output file name
-#SBATCH --error=pytorch_mnist%j.out  # error file name
+#SBATCH --error=pytorch_mnist%j.err  # error file name
 
 set -x
 cd $WORK/jean-zay-doc/examples/pytorch
@@ -16,6 +16,6 @@ cd $WORK/jean-zay-doc/examples/pytorch
 module purge
 module load pytorch-gpu/py3/1.4.0 
 
-srun python ./mnist_example.py -s&
+srun python ./mnist_example.py &
 
 wait

--- a/examples/pytorch/pytorch_example_script.sh
+++ b/examples/pytorch/pytorch_example_script.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#SBATCH --job-name=pytorch_mnist     # job name
+#SBATCH --ntasks=1                   # number of MP tasks
+#SBATCH --ntasks-per-node=1          # number of MPI tasks per node
+#SBATCH --gres=gpu:1                 # number of GPUs per node
+#SBATCH --cpus-per-task=10           # number of cores per tasks
+#SBATCH --hint=nomultithread         # we get physical cores not logical
+#SBATCH --distribution=block:block   # we pin the tasks on contiguous cores
+#SBATCH --time=3:00:00              # maximum execution time (HH:MM:SS)
+#SBATCH --output=pytorch_mnist%j.out # output file name
+#SBATCH --error=pytorch_mnist%j.out  # error file name
+
+set -x
+cd $WORK/jean-zay-doc/examples/pytorch
+
+module purge
+module load pytorch-gpu/py3/1.4.0 
+
+srun python ./mnist_example.py -s&
+
+wait

--- a/examples/pytorch/pytorch_example_script.sh
+++ b/examples/pytorch/pytorch_example_script.sh
@@ -16,6 +16,4 @@ cd $WORK/jean-zay-doc/examples/pytorch
 module purge
 module load pytorch-gpu/py3/1.4.0 
 
-srun python ./mnist_example.py &
-
-wait
+python ./mnist_example.py 

--- a/examples/pytorch/pytorch_example_script_multigpu.sh
+++ b/examples/pytorch/pytorch_example_script_multigpu.sh
@@ -18,6 +18,6 @@ module purge
 module load pytorch-gpu/py3/1.4.0 
 GAMMA_STEP=('0.1' '0.2' '0.3' '0.4' '0.5' '0.6' '0.7' '0.8' '0.9' '1.0') 
 GAMMA = echo ${GAMMA_STEP[$SLURM_ARRAY_TASK_ID]}
-srun python ./mnist_example.py --gamma GAMMA &
+srun python ./mnist_example.py --gamma $GAMMA &
 
 wait

--- a/examples/pytorch/pytorch_example_script_multigpu.sh
+++ b/examples/pytorch/pytorch_example_script_multigpu.sh
@@ -8,8 +8,8 @@
 #SBATCH --distribution=block:block   # we pin the tasks on contiguous cores
 #SBATCH --time=3:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=pytorch_mnist%j.out # output file name
-#SBATCH --error=pytorch_mnist%j.out  # error file name
-#SBATCH --array=0-9
+#SBATCH --error=pytorch_mnist%j.err  # error file name
+#SBATCH --array=1-10
 
 
 cd $WORK/jean-zay-doc/examples/pytorch
@@ -17,7 +17,6 @@ cd $WORK/jean-zay-doc/examples/pytorch
 module purge
 module load pytorch-gpu/py3/1.4.0 
 GAMMA_STEP=('0.1' '0.2' '0.3' '0.4' '0.5' '0.6' '0.7' '0.8' '0.9' '1.0') 
-GAMMA = echo ${GAMMA_STEP[$SLURM_ARRAY_TASK_ID]}
-srun python ./mnist_example.py --gamma $GAMMA &
+srun python ./mnist_example.py --gamma ${GAMMA_STEP[$SLURM_ARRAY_TASK_ID]} &
 
 wait

--- a/examples/pytorch/pytorch_example_script_multigpu.sh
+++ b/examples/pytorch/pytorch_example_script_multigpu.sh
@@ -16,7 +16,7 @@ cd $WORK/jean-zay-doc/examples/pytorch
 
 module purge
 module load pytorch-gpu/py3/1.4.0 
-GAMMA_STEP=('0.1' '0.2' '0.3' '0.4' '0.5' '0.6' '0.7' '0.8' '0.9' '1.0') 
-srun python ./mnist_example.py --gamma ${GAMMA_STEP[$SLURM_ARRAY_TASK_ID]} &
 
-wait
+GAMMA_STEP=('0.1' '0.2' '0.3' '0.4' '0.5' '0.6' '0.7' '0.8' '0.9' '1.0') 
+python ./mnist_example.py --gamma ${GAMMA_STEP[$SLURM_ARRAY_TASK_ID]} &
+

--- a/examples/pytorch/pytorch_example_script_multigpu.sh
+++ b/examples/pytorch/pytorch_example_script_multigpu.sh
@@ -12,13 +12,12 @@
 #SBATCH --array=0-9
 
 
-set -x
 cd $WORK/jean-zay-doc/examples/pytorch
 
 module purge
 module load pytorch-gpu/py3/1.4.0 
 GAMMA_STEP=('0.1' '0.2' '0.3' '0.4' '0.5' '0.6' '0.7' '0.8' '0.9' '1.0') 
 GAMMA = echo ${GAMMA_STEP[$SLURM_ARRAY_TASK_ID]}
-srun python ./mnist_example.py --gamma GAMMA -s&
+srun python ./mnist_example.py --gamma GAMMA &
 
 wait

--- a/examples/pytorch/pytorch_example_script_multigpu.sh
+++ b/examples/pytorch/pytorch_example_script_multigpu.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#SBATCH --job-name=pytorch_mnist     # job name
+#SBATCH --ntasks=1                   # number of MP tasks
+#SBATCH --ntasks-per-node=1          # number of MPI tasks per node
+#SBATCH --gres=gpu:1                 # number of GPUs per node
+#SBATCH --cpus-per-task=10           # number of cores per tasks
+#SBATCH --hint=nomultithread         # we get physical cores not logical
+#SBATCH --distribution=block:block   # we pin the tasks on contiguous cores
+#SBATCH --time=3:00:00              # maximum execution time (HH:MM:SS)
+#SBATCH --output=pytorch_mnist%j.out # output file name
+#SBATCH --error=pytorch_mnist%j.out  # error file name
+#SBATCH --array=0-9
+
+
+set -x
+cd $WORK/jean-zay-doc/examples/pytorch
+
+module purge
+module load pytorch-gpu/py3/1.4.0 
+GAMMA_STEP=('0.1' '0.2' '0.3' '0.4' '0.5' '0.6' '0.7' '0.8' '0.9' '1.0') 
+GAMMA = echo ${GAMMA_STEP[$SLURM_ARRAY_TASK_ID]}
+srun python ./mnist_example.py --gamma GAMMA -s&
+
+wait


### PR DESCRIPTION
This PR adds a Pytorch example ready to use in Jean Zay (see #9).

It uses the MNIST dataset. (~~currently asking to JZ admins to put it into the $DSDIR~~)

Fix #9.