### PR TITLE
Use a job array

### DIFF
--- a/examples/tf/mnist_submission_script_multi_gpus.slurm
+++ b/examples/tf/mnist_submission_script_multi_gpus.slurm
@@ -10,12 +10,15 @@
 #SBATCH --time=3:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=tf_mnist_multi_gpus%A_%a.out # output file name
 #SBATCH --error=tf_mnist_multi_gpus%A_%a.out  # error file name
-#SBATCH --array=0-1            # 2 jobs
+#SBATCH --array=0-1            # one job array with 2 jobs
 
 set -x
 cd $WORK/jean-zay-doc/examples/tf
 
 # no particular option here but you could imagine it being different parameters
+# for example something like:
+# opt[0]="first-value"
+# opt[1]="second-value"
 opt[0]=""
 opt[1]=""
 

--- a/examples/tf/mnist_submission_script_multi_gpus.slurm
+++ b/examples/tf/mnist_submission_script_multi_gpus.slurm
@@ -1,22 +1,27 @@
 #!/bin/bash
 #SBATCH --job-name=tf_mnist_multi_gpus     # job name
-#SBATCH --ntasks=2                   # number of MP tasks
-#SBATCH --ntasks-per-node=2          # number of MPI tasks per node
-#SBATCH --gres=gpu:2                 # number of GPUs per node
+#SBATCH --ntasks=1                   # number of MP tasks
+#SBATCH --ntasks-per-node=1          # number of MPI tasks per node
+#SBATCH --gres=gpu:1                 # number of GPUs per node
 #SBATCH --cpus-per-task=10           # number of cores per tasks
 # /!\ Caution, in the following line, "multithread" refers to hyperthreading.
 #SBATCH --hint=nomultithread         # we get physical cores not logical
 #SBATCH --distribution=block:block   # we pin the tasks on contiguous cores
 #SBATCH --time=3:00:00              # maximum execution time (HH:MM:SS)
-#SBATCH --output=tf_mnist_multi_gpus%j.out # output file name
-#SBATCH --error=tf_mnist_multi_gpus%j.out  # error file name
+#SBATCH --output=tf_mnist_multi_gpus%A_%a.out # output file name
+#SBATCH --error=tf_mnist_multi_gpus%A_%a.out  # error file name
+#SBATCH --array=0-1            # 2 jobs
 
 set -x
 cd $WORK/jean-zay-doc/examples/tf
 
+# no particular option here but you could imagine it being different parameters
+opt[0]=""
+opt[1]=""
+
 module purge
 module load tensorflow-gpu/py3/2.1.0
 
-srun --multi-prog ./mpmd_multi_gpu.conf
+srun python ./mnist_example.py ${opt[$SLURM_ARRAY_TASK_ID]}
 
 wait

--- a/examples/tf/mnist_submission_script_multi_gpus.slurm
+++ b/examples/tf/mnist_submission_script_multi_gpus.slurm
@@ -15,10 +15,10 @@
 set -x
 cd $WORK/jean-zay-doc/examples/tf
 
-# no particular option here but you could imagine it being different parameters
-# for example something like:
-# opt[0]="first-value"
-# opt[1]="second-value"
+# no particular option here but you could imagine it being different parameters,
+# for example for running two jobs with differente learning rates (0.1 and 1):
+# opt[0]="0.1"
+# opt[1]="1"
 opt[0]=""
 opt[1]=""
 

--- a/examples/tf/mpmd_multi_gpu.conf
+++ b/examples/tf/mpmd_multi_gpu.conf
@@ -1,2 +1,0 @@
-0 python ./mnist_example.py -gpus 0
-1 python ./mnist_example.py -gpus 1


### PR DESCRIPTION
This addresses [this comment](https://github.com/jean-zay-users/jean-zay-doc/issues/9#issuecomment-595871316) in #9 .

The advantages of using sbatch array over mpmd conf are:
- it's easier to write/maintain (especially because you don't need a second file)
- it produces as many output files as you have parameters instances, so you can inspect them more easily and it's less messy

This was tested on JZ.