### PR TITLE
Add links to repository in example pages and update containers information

### DIFF
--- a/docs/examples/pytorch/distributed_stl10/README.md
+++ b/docs/examples/pytorch/distributed_stl10/README.md
@@ -2,22 +2,20 @@
 
 stl10_example.py is based on [https://github.com/pytorch/examples/tree/master/imagenet](https://github.com/pytorch/examples/tree/master/imagenet).
 
+You can then launch the job with:
+```
+cd jean-zay-doc/examples/pytorch/distributed_stl10/
+sbatch ./pytorch_distributed_stl10_example.sh
+```
+
+Here is the code:
+{{code_from_file("examples/pytorch/distributed_stl10/stl10_example.py", "python")}}
+
 ## Slurm configuration
 
-By default we use the following configuration. 
+By default we use the following configuration:
 
-```bash
-#!/bin/bash
-#SBATCH --job-name=pytorch_stl10     # job name
-#SBATCH --ntasks=2                   # number of MP tasks
-#SBATCH --ntasks-per-node=1          # number of MPI tasks per node
-#SBATCH --gres=gpu:1                 # number of GPUs per node
-#SBATCH --cpus-per-task=10           # number of cores per tasks
-#SBATCH --hint=nomultithread         # we get physical cores not logical
-#SBATCH --time=00:10:00              # maximum execution time (HH:MM:SS)
-#SBATCH --output=pytorch_stl10%j.out # output file name
-#SBATCH --error=pytorch_stl10%j.err  # error file name
-```
+{{code_from_file("examples/pytorch/distributed_stl10/pytorch_distributed_stl10_example.sh", "bash")}}
 
 This configuration will start a distributed training on two nodes with one GPU
 each. 
@@ -57,10 +55,4 @@ partition):
 #SBATCH --time=00:10:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=pytorch_stl10%j.out # output file name
 #SBATCH --error=pytorch_stl10%j.err  # error file name
-```
-
-You can then launch the job with:
-```
-cd jean-zay-doc/examples/pytorch/distributed_stl10/
-sbatch ./pytorch_distributed_stl10_example.sh
 ```

--- a/docs/examples/pytorch/distributed_stl10/README.md
+++ b/docs/examples/pytorch/distributed_stl10/README.md
@@ -1,4 +1,4 @@
-# PyTorch STL10 example script
+# [PyTorch STL10 example script](https://github.com/jean-zay-users/jean-zay-doc/tree/master/docs/examples/pytorch/distributed_stl10)
 
 stl10_example.py is based on [https://github.com/pytorch/examples/tree/master/imagenet](https://github.com/pytorch/examples/tree/master/imagenet).
 

--- a/docs/examples/pytorch/mnist/README.md
+++ b/docs/examples/pytorch/mnist/README.md
@@ -1,4 +1,4 @@
-# Pytorch MNIST example script
+# [Pytorch MNIST example script](https://github.com/jean-zay-users/jean-zay-doc/tree/master/docs/examples/pytorch/mnist)
 
 You can launch the batch job (single GPU version) via:
 ```

--- a/docs/examples/pytorch/mnist/README.md
+++ b/docs/examples/pytorch/mnist/README.md
@@ -18,3 +18,11 @@ during the training:
 cd jean-zay-doc/docs/examples/pytorch/mnist/
 sbatch ./pytorch_example_script_multigpu.sh
 ```
+
+This is the example script (`mnist_example.py`):
+
+{{code_from_file("examples/pytorch/mnist/mnist_example.py", "python")}}
+
+And the launching script for a single GPU version (`pytorch_example_script.sh`):
+
+{{code_from_file("examples/pytorch/mnist/pytorch_example_script.sh", "bash")}}

--- a/docs/examples/tf/tf_mpi/README.md
+++ b/docs/examples/tf/tf_mpi/README.md
@@ -26,3 +26,14 @@ There is a few important things:
 cd jean-zay-doc/docs/examples/tf/tf_mpi
 sbatch tf_mpi_mnist.job
 ```
+
+## Code
+
+The code for the distributed training (`tf_mpi_mnist.py`):
+
+{{code_from_file("examples/tf/tf_mpi/tf_mpi_mnist.py", "python")}}
+
+and the script to launch the job:
+
+{{code_from_file("examples/tf/tf_mpi/tf_mpi_mnist.job", "bash")}}
+

--- a/docs/examples/tf/tf_mpi/README.md
+++ b/docs/examples/tf/tf_mpi/README.md
@@ -1,4 +1,4 @@
-# MNIST with TensorFlow using MPI through Horovod
+# [MNIST with TensorFlow using MPI through Horovod](https://github.com/jean-zay-users/jean-zay-doc/tree/master/docs/examples/tf/tf_mpi)
 
 This toy-example shows how to do distributed training using TensorFlow and
 Horovod.  Since Jean-Zay nodes are connected using MPI and with NCCL,

--- a/docs/examples/tf/tf_simple/README.md
+++ b/docs/examples/tf/tf_simple/README.md
@@ -26,6 +26,18 @@ jean-zay-doc/docs/examples/tf/tf_simple
 sbatch mnist_submission_script_multi_gpus.slurm
 ```
 
+The training code used in this example is:
+
+{{code_from_file("examples/tf/tf_simple/mnist_example.py", "python")}}
+
+and the script used to launch a single GPU job is:
+
+{{code_from_file("examples/tf/tf_simple/mnist_submission_script.slurm", "bash")}}
+
+to launch the same code using a multiGPU configuration, use the following script:
+
+{{code_from_file("examples/tf/tf_simple/mnist_submission_script_multi_gpus.slurm", "bash")}}
+
 ## Dask example
 
 To run the dask example you will need to install `dask-jobqueue` in your
@@ -52,3 +64,7 @@ otherwise Tensorflow will not be loaded.  This is because the python executable
 used to launch the dask worker is the same as the one used to launch the
 scheduler by default.  You can set it otherwise in the cluster if you want
 something more tailored.
+
+Here is the code for the file `dask_script.py`:
+
+{{code_from_file("examples/tf/tf_simple/dask_script.py", "python")}}

--- a/docs/examples/tf/tf_simple/README.md
+++ b/docs/examples/tf/tf_simple/README.md
@@ -1,4 +1,4 @@
-# TensorFlow single node examples
+# [TensorFlow single node examples](https://github.com/jean-zay-users/jean-zay-doc/tree/master/docs/examples/tf/tf_simple)
 
 To run the examples you will need to first install `click` in your environment.
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,9 @@
 # Jean Zay users
 ## Collaborative documentation
-
 ---
+[![Gitter](https://img.shields.io/gitter/room/jean-zay-users/jean-zay-doc.svg)](https://gitter.im/jean-zay-users/jean-zay-doc)
+[![Docs](https://readthedocs.org/projects/jean-zay-doc/badge/?version=latest)](https://jean-zay-doc.readthedocs.io/en/latest/?badge=latest)
+
 
 ## Why this doc?
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -17,7 +17,7 @@ http://www.idris.fr/eng/jean-zay/cpu/jean-zay-utilisation-singularity-eng.html**
 ## SSH port forwarding disabled
 
 SSH port forwarding is disabled by Jean Zay sys-admin for security reasons.
-([Loïc](https://github.com/lesteve)) have a work-around, if you are interested
+[Loïc](https://github.com/lesteve) has a work-around, if you are interested
 contact him!
 
 <img src="../img/ssh-port-forwarding-info.jpg"/>

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -4,14 +4,15 @@ a [Pull Request](https://github.com/jean-zay-users/jean-zay-doc/compare)!
 
 # Limitations
 
-## docker image usage
+## Singularity/docker image usage
 
 There is currently no way of using a docker image on Jean Zay. They are working
 on it but at the time of writing (end January 2020) it is likely to take
 between 3 and 6 months so be ready for some time between May and August 2020.
 
-Last time we heard (February 2020) from this effort, `singularity` would be the
-tool available on Jean Zay to run docker images.
+**Update (novemeber 2020): Singularity is available. See here for the full
+official documentation:
+http://www.idris.fr/eng/jean-zay/cpu/jean-zay-utilisation-singularity-eng.html**
 
 ## SSH port forwarding disabled
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -16,9 +16,9 @@ http://www.idris.fr/eng/jean-zay/cpu/jean-zay-utilisation-singularity-eng.html**
 
 ## SSH port forwarding disabled
 
-SSH port forwarding is disabled by Jean Zay sys-admin for security reasons. I
+SSH port forwarding is disabled by Jean Zay sys-admin for security reasons.
 ([Loïc](https://github.com/lesteve)) have a work-around, if you are interested
-contact me!
+contact him!
 
 <img src="../img/ssh-port-forwarding-info.jpg"/>
 

--- a/docs/macros.py
+++ b/docs/macros.py
@@ -1,0 +1,42 @@
+## Macros file to be used with mkdocs_macros_plugin
+## This snippet is taken from this issue 
+## https://github.com/mkdocs/mkdocs/issues/692
+
+import html
+import os
+
+def declare_variables(variables, macro):
+    @macro
+    def code_from_file(fn: str, flavor: str = ""):
+        """
+        Load code from a file and save as a preformatted code block.
+        If a flavor is specified, it's passed in as a hint for syntax highlighters.
+
+        Example usage in markdown:
+
+            {{code_from_file("code/myfile.py", "python")}}
+
+        """
+        docs_dir = variables.get("docs_dir", "docs")
+        fn = os.path.abspath(os.path.join(docs_dir, fn))
+        if not os.path.exists(fn):
+            return f"""<b>File not found: {fn}</b>"""
+        with open(fn, "r") as f:
+            source = f.read()
+            return f"```{flavor}\n{source}```" 
+
+    @macro
+    def external_markdown(fn: str):
+        """
+        Load markdown from files external to the mkdocs root path.
+        Example usage in markdown:
+
+            {{external_markdown("../../README.md")}}
+
+        """
+        docs_dir = variables.get("docs_dir", "docs")
+        fn = os.path.abspath(os.path.join(docs_dir, fn))
+        if not os.path.exists(fn):
+            return f"""<b>File not found: {fn}</b>"""
+        with open(fn, "r") as f:
+            return f.read()

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ mkdocs>=1.1
 mkdocs-bootswatch
 mkdocs-material
 pymdown-extensions
+mkdocs-macros-plugin

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,11 @@ markdown_extensions:
   - toc:
       permalink: True
 
+plugins:
+  - search
+  - macros:
+      module_name: docs/macros
+
 # Page tree
 nav:
   - Home: index.md


### PR DESCRIPTION
- Add links to the code in the repository in the examples page.
- Update information about containers (and add link to the webpage of how to use singularity in Jean Zay).
- Add mkdocs macro to insert code files into documentation (see examples).