### PR TITLE
ENH add instruction for bash_profile

### DIFF
--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -1,5 +1,18 @@
 # Tips and Tricks
 
+## Bash config
+
+By default, the `.bashrc` is not executed when connecting on the cluster.
+To make sure it is run, add a file `~/.bash_profile` with
+
+```bash
+#
+# ~/.bash_profile
+#
+
+[[ -f ~/.bashrc ]] && . ~/.bashrc
+```
+
 ## Python
 
 ### Install miniconda (recommended solution if you are already familiar with conda)


### PR DESCRIPTION
I had some issue understanding why the `.bashrc` was not executed when I first connected on the cluster.
My fix was adding a `.bash_profile` to call the `.bashrc`. Not sure if this is necessary but if so, documented it would help :)