### PR TITLE
Time limits in two examples for qos dev

### DIFF
--- a/docs/examples/tf/tf_simple/mnist_submission_script.slurm
+++ b/docs/examples/tf/tf_simple/mnist_submission_script.slurm
@@ -7,7 +7,7 @@
 # /!\ Caution, in the following line, "multithread" refers to hyperthreading.
 #SBATCH --hint=nomultithread         # we get physical cores not logical
 #SBATCH --distribution=block:block   # we pin the tasks on contiguous cores
-#SBATCH --time=3:00:00              # maximum execution time (HH:MM:SS)
+#SBATCH --time=2:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=tf_mnist%j.out # output file name
 #SBATCH --error=tf_mnist%j.out  # error file name
 #SBATCH --qos=qos_gpu-dev         # we are submitting a test job

--- a/docs/examples/tf/tf_simple/mnist_submission_script_multi_gpus.slurm
+++ b/docs/examples/tf/tf_simple/mnist_submission_script_multi_gpus.slurm
@@ -7,7 +7,7 @@
 # /!\ Caution, in the following line, "multithread" refers to hyperthreading.
 #SBATCH --hint=nomultithread         # we get physical cores not logical
 #SBATCH --distribution=block:block   # we pin the tasks on contiguous cores
-#SBATCH --time=3:00:00              # maximum execution time (HH:MM:SS)
+#SBATCH --time=2:00:00              # maximum execution time (HH:MM:SS)
 #SBATCH --output=tf_mnist_multi_gpus%A_%a.out # output file name
 #SBATCH --error=tf_mnist_multi_gpus%A_%a.out  # error file name
 #SBATCH --array=0-1            # one job array with 2 jobs


### PR DESCRIPTION
Hello,

According to the [documentation](http://www.idris.fr/jean-zay/gpu/jean-zay-gpu-exec_partition_slurm.html#les_qos_disponibles), the time limit for QoS qos_gpu-dev is 2h instead of 3h.