### PR TITLE
Fix path in Pytorch STL10 example

### DIFF
--- a/docs/examples/pytorch/distributed_stl10/README.md
+++ b/docs/examples/pytorch/distributed_stl10/README.md
@@ -4,7 +4,7 @@ stl10_example.py is based on [https://github.com/pytorch/examples/tree/master/im
 
 You can then launch the job with:
 ```
-cd jean-zay-doc/examples/pytorch/distributed_stl10/
+cd jean-zay-doc/docs/examples/pytorch/distributed_stl10/
 sbatch ./pytorch_distributed_stl10_example.sh
 ```
 


### PR DESCRIPTION
There is a typo in a path in the [Pytorch STL10 example script ](https://jean-zay-doc.readthedocs.io/en/latest/examples/pytorch/distributed_stl10/), this PR fixes it