### PR TITLE
Add tip on changing the default file permission sets to make collaboration easier

### DIFF
--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -216,7 +216,9 @@ rsync -avz /your/local/database/ \
 !!! warning
     The number of inodes seem to be a bottleneck for Jean-Zay platform. Do not expect a too high number of obtained requests.
 
+### Changing the default file permission sets to make collaboration easier
 
+By default, users has a umask value (i.e. the default file permission sets for newly created files and folders) of 0027, which in symbolic notation translates to `u=rwx,g=rx,o=`. That means if you have colleagues assigned to the same project/group, they won't have write permissions on the files and directories you create, which can be annoying if you want to collaborate in a common disk space such as `$ALL_CCFRWORK`. To add group-write permissions by default, you can execute `umask 007` which will change the umask value for the current shell session; or to make it permanent, add the line `umask 007` at the beginning of your `~/.bash_profile`.
 
 ### Using available datasets
 


### PR DESCRIPTION
This proposes a simple tip that I found to make collaboration easier, as I thought it would be relevant to add this to the docs.
