### PR TITLE
Recommend using miniforge

### DIFF
--- a/docs/tips/python.md
+++ b/docs/tips/python.md
@@ -5,8 +5,8 @@
 Install `miniconda` in `$WORK/miniconda3`:
 
 ```bash
-# download Miniconda installer
-wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+# download Miniconda installer (from conda-forge)
+wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh \
     -O miniconda.sh
 # install Miniconda
 MINICONDA_PATH=$WORK/miniconda3


### PR DESCRIPTION
main reasons:
- packages tend to be a lot more up-to-date on conda-forge than on the `defaults` channel
- in the past (a while ago not sure exactly when) one reason to not use conda-forge was because only PyTorch CPU was available, but these days you can do `conda install pytorch-gpu`
- mixing packages from `defaults` and `conda-forge` can lead to some weird issues in some edge cases
