### PR TITLE
Fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ for instructions.
 The documentation is using [mkdocs](https://www.mkdocs.org/) with a few
 plugins. To install them:
 ```
-pip install -e requirements.txt
+pip install -r requirements.txt
 ```
 
 To run `mkdocs` in development mode:

--- a/docs/access-procedure.md
+++ b/docs/access-procedure.md
@@ -24,7 +24,7 @@ is detailed in the sections below.
 2. Fill a form about your project (**"Déclaration de dossier"**). Hardest part
    is to figure out who your "Directeur de la structure de recherche" is and to
    have the form signed by him/her. You also need to write a few lines about
-   your project. See [this](#d%C3%A9claration-de-dossier-project-description)
+   your project. See [this](#declaration-de-dossier-project-description)
    for all the details about this step.
 3. Fill a form about to get a computing account (**"Déclaration de compte
    calcul"**). Hardest part is to figure out who your "Responsable Sécurité

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,10 +31,10 @@ We use gitter for chat, don't hesitate to get involved
   important one is the access procedure. It will take roughly 3 weeks (add 1-2
   months on top of that if you have to go through additional security
   background checks). It does seem long but it is definitely worth it.
-- [Tips and tricks](./tips-and-tricks.md)
+- [Tips and tricks](./tips/index.md)
 - [Limitations](./limitations.md)
-- Example scripts: [PyTorch examples](./examples/pytorch), [Tensorflow
-  examples](./examples/tf), [Tensorflow MPI distributed examples](.examples/tf_mpi/).
+- Example scripts: [PyTorch examples](./examples/pytorch/README.md), [Tensorflow
+  examples](./examples/tf/README.md), [Tensorflow MPI distributed examples](./examples/tf/tf_mpi/README.md).
 
 In the medium term, more material could be added to discuss tips and tricks,
 limitations, work-arounds, etc ... on Jean Zay. In particular, feel free to
@@ -59,16 +59,20 @@ the Jean Zay cluster, e.g.:
   on Jean Zay
 
 ### Jean-Zay official doc links
+- [Jean Zay new official documentation](http://www.idris.fr/docs/jean-zay/nouvel-utilisateur/)
 
-- [Jean Zay official doc targeted towards AI users](http://www.idris.fr/eng/ia/index.htm)
+- [Jean Zay Cheatsheet](http://www.idris.fr/assets/files/idrismemento_sans_bbftp-7aa909712545a6d2513ccd644b06fcaa.pdf)
+#### Archive
+Jean Zay has updated their official documentation website, but the new one is not translated in English yet, they advise to use browser translation. However it is still possible to access the archived English version and the specific documentation, please note that they might not be up-to-date with the latest changes.
 
-- [Jean Zay Official Doc](http://www.idris.fr/eng/jean-zay/)
+- [Jean Zay archived Doc targeted towards AI users](http://archive.idris.fr/eng/ia/index.html)
 
-- [Jean Zay official Doc in French (more accurate sometimes)](http://www.idris.fr/jean-zay/index.html)
+- [Jean Zay archived Doc](http://archive.idris.fr/eng/jean-zay/)
 
-- [Jean Zay Hardware](http://www.idris.fr/eng/jean-zay/cpu/jean-zay-cpu-hw-eng.html)
+- [Jean Zay archived Doc in French (more accurate sometimes)](http://archive.idris.fr/jean-zay/index.html)
 
-- [Jean Zay Cheatsheet](http://www.idris.fr/media/su/idrismemento1.pdf)
+- [Jean Zay Hardware](http://archive.idris.fr/eng/jean-zay/cpu/jean-zay-cpu-hw-eng.html)
+
 
 
 ## Generic advice

--- a/docs/tips/index.md
+++ b/docs/tips/index.md
@@ -1,0 +1,10 @@
+# Tips and tricks
+
+A collection of practical tips to get productive on Jean Zay.
+
+- [Shell configuration](./shell.md) — bash, .bashrc, alternative shells
+- [Python](./python.md) — installing miniconda, managing Python environments
+- [JupyterHub](./jupyterhub.md) — UI interfaces for launching jobs
+- [SLURM](./slurm.md) — interactive jobs, job scripts, GPU reservations
+- [Singularity](./singularity.md) — using containers on the cluster
+- [Miscellaneous](./miscellaneous.md) — storage spaces, data management, and more


### PR DESCRIPTION
Jean zay has a new documentation website but not yet an english translation, updated the documentation link and linked to the archive for previous website interesting ressource.

Fixed installation scripts : 
typo in `pip install -r requirements.txt`

Fixed internal links: some internal links were pointing to files that moved, updated them to link to the correct page